### PR TITLE
Auto-select streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='0.4.1',
+      version='0.4.2',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -30,6 +30,16 @@ def get_schemas():
         SCHEMAS[stream_name] = schema
 
         metadata = []
+
+        # auto-select all streams
+        metadata.append({
+            'metadata': {
+                'selected': True,
+                'inclusion': 'available'
+            },
+            'breadcrumb': []
+        })
+
         for prop, json_schema in schema['properties'].items():
             if prop == 'id':
                 inclusion = 'automatic'


### PR DESCRIPTION
This is so that we can auto-select streams when generating catalogs per https://linear.app/pathlight/issue/PL-1086/automatically-select-all-streams-for-catalogs-in-tap-configs